### PR TITLE
Add doc comments to client.Subscriber calls

### DIFF
--- a/pubsub/subscriptions/async_pull.go
+++ b/pubsub/subscriptions/async_pull.go
@@ -36,6 +36,9 @@ func pullMsgs(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.

--- a/pubsub/subscriptions/async_pull_custom_attributes.go
+++ b/pubsub/subscriptions/async_pull_custom_attributes.go
@@ -34,6 +34,9 @@ func pullMsgsCustomAttributes(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.

--- a/pubsub/subscriptions/dead_letter_delivery_attempt.go
+++ b/pubsub/subscriptions/dead_letter_delivery_attempt.go
@@ -40,6 +40,9 @@ func pullMsgsDeadLetterDeliveryAttempt(w io.Writer, projectID, subID string) err
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 	err = sub.Receive(ctx, func(_ context.Context, msg *pubsub.Message) {
 		// When dead lettering is enabled, the delivery attempt field is a pointer to the

--- a/pubsub/subscriptions/optimistic_subscribe.go
+++ b/pubsub/subscriptions/optimistic_subscribe.go
@@ -41,6 +41,9 @@ func optimisticSubscribe(w io.Writer, projectID, topic, subscriptionName string)
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subscriptionName)
 
 	// Receive messages for 10 seconds, which simplifies testing.
@@ -68,6 +71,9 @@ func optimisticSubscribe(w io.Writer, projectID, topic, subscriptionName string)
 				}
 				fmt.Fprintf(w, "Created subscription: %q\n", subscriptionName)
 
+				// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+				// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+				// If a subscription ID is provided, the project ID from the client is used.
 				sub = client.Subscriber(subscription.GetName())
 				err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 					fmt.Fprintf(w, "Got from new subscription: %q\n", string(msg.Data))

--- a/pubsub/subscriptions/pull_concurrency.go
+++ b/pubsub/subscriptions/pull_concurrency.go
@@ -35,6 +35,9 @@ func pullMsgsConcurrencyControl(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 	// NumGoroutines determines the number of streams sub.Receive will spawn to pull
 	// messages. It is recommended to set this to 1, unless your throughput

--- a/pubsub/subscriptions/pull_error.go
+++ b/pubsub/subscriptions/pull_error.go
@@ -35,6 +35,9 @@ func pullMsgsError(w io.Writer, projectID, subID string) error {
 
 	// If the service returns a non-retryable error, Receive returns that error after
 	// all of the outstanding calls to the handler have returned.
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 	err = sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
 		fmt.Fprintf(w, "Got message: %q\n", string(msg.Data))

--- a/pubsub/subscriptions/pull_exactly_once_delivery.go
+++ b/pubsub/subscriptions/pull_exactly_once_delivery.go
@@ -43,6 +43,9 @@ func receiveMessagesWithExactlyOnceDeliveryEnabled(w io.Writer, projectID, subID
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 	// Set MinDurationPerAckExtension high to avoid any unintentional
 	// acknowledgment expirations (e.g. due to network events).

--- a/pubsub/subscriptions/pull_otel_tracing.go
+++ b/pubsub/subscriptions/pull_otel_tracing.go
@@ -73,6 +73,9 @@ func subscribeOpenTelemetryTracing(w io.Writer, projectID, subID string, sampleR
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 
 	// Receive messages for 10 seconds, which simplifies testing.

--- a/pubsub/subscriptions/pull_settings.go
+++ b/pubsub/subscriptions/pull_settings.go
@@ -33,6 +33,9 @@ func pullMsgsFlowControlSettings(w io.Writer, projectID, subID string) error {
 	}
 	defer client.Close()
 
+	// client.Subscriber can be passed a subscription ID (e.g. "my-sub") or
+	// a fully qualified name (e.g. "projects/my-project/subscriptions/my-sub").
+	// If a subscription ID is provided, the project ID from the client is used.
 	sub := client.Subscriber(subID)
 	// MaxOutstandingMessages is the maximum number of unprocessed messages the
 	// subscriber client will pull from the server before pausing. This also configures


### PR DESCRIPTION
Clarify that client.Subscriber accepts either a resource ID or a fully qualified name for the subscription. If a resource ID is used, the project ID from the client is assumed.